### PR TITLE
Add two different issue templates

### DIFF
--- a/.github/Bug_report.md
+++ b/.github/Bug_report.md
@@ -1,0 +1,16 @@
+---
+name: Incorrect Version
+about: Report any incorrect versions of songs from the radiostations
+---
+
+I found in [Playlistname](#link/to7playlist) an incorrect version.
+
+On Platform ` ` is a better || the correct version for the song ` ` from ` ` in the game.
+
+[Link to the song on the specific Platform.]: #
+
+* [ ] I searched the issues and there was no issue regarding this song change
+* [ ] I made sure this song is no local song for me
+
+[Please @mention the current maintainer of the list so the maintainer can look at it]: #
+[Currently @h4llow3En for Apple Music and @marauderxtreme for Spotify]: #

--- a/.github/Feature_request.md
+++ b/.github/Feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Missing song
+about: Report any missing songs from the raediostations
+---
+
+I found a song on Platform ` ` that is listed as not available in [Playlistname](#link/to7playlist).
+Would you kindly include it?
+
+[Link to the song on the specific Platform.]: #
+
+* [ ] I searched the issues and there was no issue regarding this song inclusion
+* [ ] I made sure this song is no local song for me
+
+[Please @mention the current maintainer of the list so the maintainer can look at it]: #
+[Currently @h4llow3En for Apple Music and @marauderxtreme for Spotify]: #


### PR DESCRIPTION
I created a "Bug Report" template for incorrect song versions in our lists and proposals for better versions of them.
Additionally I created a "Feature Request" template for songs that came new to the platforms, after we put the playlist together and is currently listed as missing.