### PR TITLE
Update K12 97.6 from Saints Row IV

### DIFF
--- a/Saints Row/IV/K12 97.6.md
+++ b/Saints Row/IV/K12 97.6.md
@@ -15,7 +15,7 @@ Prophecies                     | Alex Metric               | ✓          | ✓
 Eat My Apple                   | Apashe                    | ✓          | ✓
 Ivory (Bloody Beetroots Mix)   | Congorock                 | ✓          | ✓
 Vindicate                      | Datsik & Excision         | ✓          | ✓
-Bonafide Hustler (Trap VIP)    | Datsik                    | ✗          | (✓)
+Bonafide Hustler (Trap VIP)    | Datsik                    | ✗          | ✗
 Flying Spaghetti Monster       | Doctor P                  | ✓          | ✓
 Blow the Roof                  | Flux Pavillion            | ✓          | ✓
 All My Life                    | Gigamesh                  | ✓          | ✓
@@ -25,5 +25,5 @@ Promises                       | Nero                      | ✓          | ✓
 The Source (Chaos & Confusion) | The Bloody Beetroots      | ✓          | ✓
 Geronimo                       | The Knocks and Fred Falke | ✓          | ✓
 Stamina                        | Vitalic                   | ✓          | ✓
-Poppin Off                     | Watch the Duck            | ✗          | ✓
+Poppin Off                     | Watch the Duck            | ✗          | ✗
 Speed Ball                     | Kirkwood West             | ✗          | ✗


### PR DESCRIPTION
* Bonafide Hustler (Trap VIP) - Datsik got removed from amusic
* Poppin Off - Watch the Duck got removed from amusic