### PR TITLE
Fix song info in 106.66 The Blood of SR The Third

### DIFF
--- a/Saints Row/The Third/106.66 The Blood.md
+++ b/Saints Row/The Third/106.66 The Blood.md
@@ -29,4 +29,4 @@
 | Necropolis                       | The Black Dahlia Murder     | ✓          | ✓              |
 | Farewell Mona Lisa               | The Dillinger Escape Plan   | ✓          | ✓              |
 | Slow Revolution                  | Tugboat                     | ✗          | ✗              |
-| Engine Wrecks                    | You Love Her Coz She's Dead | ✗          | ✗              |
+| Engine Wrecker                   | PP Music                    | ✓          | ✗              |


### PR DESCRIPTION
The song is apparently called Engine Wrecker and is performed by PP Music and not Engine Wrecks by You Love Her Coz She's Dead. This was revealed by Shazam and confirmed by hearing it in game.